### PR TITLE
feature: PPS-72 add ruling system

### DIFF
--- a/src/main/scala/Application.scala
+++ b/src/main/scala/Application.scala
@@ -4,11 +4,10 @@ import org.unibo.scooby.utility.document.html.HTMLElement
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
-
 import Application.scooby
 import dsl.ScoobyEmbeddable
-import org.unibo.scooby.dsl.Scrape.haveAttribute
-import org.unibo.scooby.dsl.Scrape.haveAttributeValue
+
+import org.unibo.scooby.dsl.Scrape.{element, haveAttribute, haveAttributeValue, rule}
 import cats.syntax.group
 
 object Application extends ScoobyEmbeddable with App:
@@ -28,11 +27,12 @@ object Application extends ScoobyEmbeddable with App:
       policy:
         links
     scrape:
-      elements that (haveAttribute("href") and dont(
-        haveAttributeValue("href", "/domains/reserved") or
-        haveAttributeValue("href", "/about")
-      ))
-
+      elements that :
+        haveAttribute("href") and dont:
+          haveAttributeValue("href", "/domains/reserved") or
+          haveAttributeValue("href", "/about")
+        .and:
+          rule { element.tag == "a" } and rule { element.tag == "div" }
     exports:
       Batch:
         strategy:

--- a/src/main/scala/dsl/DSL.scala
+++ b/src/main/scala/dsl/DSL.scala
@@ -9,7 +9,7 @@ object DSL:
   export Config.*
   export Crawl.*
   export Scrape.{scrape, document, matchesOf, select, elements, tag, classes, attributes, get, and, id,
-                haveClass, haveId, haveTag, that, dont, including, or}
+                haveClass, haveId, haveTag, that, dont, including, or, rule}
   export Export.*
 
   case class ScrapingResultSetting[T]()

--- a/src/main/scala/dsl/Scrape.scala
+++ b/src/main/scala/dsl/Scrape.scala
@@ -27,16 +27,18 @@ object Scrape:
 
   def document[T <: Document & CommonHTMLExplorer](using documentContext: T): T = documentContext
 
-  def elements[T <: Document & CommonHTMLExplorer](using documentContext: T): Iterable[HTMLElement] = 
+  def elements[T <: Document & CommonHTMLExplorer](using documentContext: T): Iterable[HTMLElement] =
     documentContext.getAllElements
-
+  
+  def element(using el: HTMLElement): HTMLElement = el
+  
   def matchesOf[T <: Document & RegExpExplorer](regExp: String)(using documentContext: T): Iterable[String] =
     documentContext.find(regExp)
 
   def select[T <: Document & SelectorExplorer](selectors: String*)(using documentContext: T): Iterable[HTMLElement] =
     documentContext.select(selectors*)
 
-  def tag: HTMLElement => String = _.tag 
+  def tag: HTMLElement => String = _.tag
   def classes: HTMLElement => Iterable[String] = _.classes
   def attributes: HTMLElement => Iterable[(String, String)] = _.attributes
   def id: HTMLElement => String = _.id
@@ -47,20 +49,29 @@ object Scrape:
   infix def haveClass(cssClass: String): HTMLElement => Boolean = _.classes.contains(cssClass)
   infix def haveId(id: String): HTMLElement => Boolean = _.id == id
   infix def haveAttribute(attributeName: String): HTMLElement => Boolean = _.attr(attributeName).nonEmpty
-  infix def haveAttributeValue(attributeName: String, attributeValue: String): HTMLElement => Boolean = 
+  infix def haveAttributeValue(attributeName: String, attributeValue: String): HTMLElement => Boolean =
     _.attr(attributeName) == attributeValue
+
+  infix def rule(init: HTMLElement ?=> Boolean): HTMLElement => Boolean =
+    el =>
+      given HTMLElement = el
+      init
+      
+      
+    
 
   extension[T] (x: Iterable[T])
     infix inline def including[S >: T](y: Iterable[S]): Iterable[S] = x concat y
 
-    infix inline def that(predicate: (T) => Boolean): Iterable[T] = x filter predicate
+    infix inline def that(predicate: T => Boolean): Iterable[T] = x filter predicate
 
   extension[T](x: Iterable[T])
     infix def get[A](f: T => A): Iterable[A] = x.map(f)
 
-  extension[T] (x: T => Boolean)
-    infix def and(y: T => Boolean): T => Boolean = (el) => x(el) && y(el) 
-    infix def &&(y: T => Boolean): T => Boolean = and(y)
-    infix def or(y: T => Boolean): T => Boolean = (el) => x(el) || y(el) 
-    infix def ||(y: T => Boolean): T => Boolean = or(y)
   
+
+  extension[T] (x: T => Boolean)
+    infix def and(y: T => Boolean): T => Boolean = (el) => x(el) && y(el)
+    infix def &&(y: T => Boolean): T => Boolean = and(y)
+    infix def or(y: T => Boolean): T => Boolean = (el) => x(el) || y(el)
+    infix def ||(y: T => Boolean): T => Boolean = or(y)


### PR DESCRIPTION
Add methods for describing the behaviour of the scraper: 

- Implement `rule` keyword for describing a rule on a single `HTMLElement`.
- Implement logical concatenations methods: `or, and` and `not` 
