### PR TITLE
Refactor: removed ScrapingResultSetting class

### DIFF
--- a/src/main/scala/core/crawler/Crawler.scala
+++ b/src/main/scala/core/crawler/Crawler.scala
@@ -191,6 +191,8 @@ class Crawler[T](context: ActorContext[CrawlerCommand],
             context.log.info(s"${context.self.path.name} has reached max depth! Terminating...")
             buffer.unstashAll(waitingForChildren(1))
 
+    end crawl
+
     /**
      * Sub-behavior for the Crawler that recursively spawns the children Crawlers.
      * @param links valid links that get visited. One [[Crawler]] is spawned for each.
@@ -211,12 +213,18 @@ class Crawler[T](context: ActorContext[CrawlerCommand],
 
       buffer.unstashAll(waitingForChildren(linkList.size + 1))
 
+    end visitChildren
+
+    // Idle message handling
+
     Behaviors.receiveMessage:
       case Crawl(url) => crawl(url)
       case CrawlerCoordinatorResponse(links) => visitChildren(links)
       case x: ChildTerminated =>
         buffer.stash(x)
         Behaviors.same
+
+  end idle
 
   /**
    * Last behavior for the Crawler. During this phase, the Crawler waits for all its children (crawlers and scraper) to

--- a/src/main/scala/dsl/DSL.scala
+++ b/src/main/scala/dsl/DSL.scala
@@ -19,18 +19,11 @@ object DSL:
   export core.exporter.JsonConverter.htmlElementWrites
 
   /**
-   * Temporary empty class to hold the scraping result type.
-   * @tparam T type of the scraping result
-   */
-  case class ScrapingResultSetting[T]()
-
-  /**
    * Wrapper available at the global level of the DSL, necessary to build the final Scooby configuration
    * @param configuration variable configuration, modified throughout the DSL usage
-   * @param scrapingResultSetting object symbolizing the scraping result type
    * @tparam T type of the [[Configuration]]
    */
-  class ConfigurationWrapper[T](var configuration: Configuration[T], var scrapingResultSetting: ScrapingResultSetting[T]):
+  class ConfigurationWrapper[T](var configuration: Configuration[T]):
     def value: Configuration[T] = configuration
 
   /**

--- a/src/main/scala/dsl/Entrypoint.scala
+++ b/src/main/scala/dsl/Entrypoint.scala
@@ -10,7 +10,7 @@ import monocle.syntax.all.*
 import scala.concurrent.{Future, Promise}
 import scala.util.Success
 import core.scooby.SingleExporting
-import org.unibo.scooby.dsl.DSL.{ConfigurationWrapper, ScrapingResultSetting}
+import org.unibo.scooby.dsl.DSL.ConfigurationWrapper
 
 /**
  * Generated an empty [[ConfigurationWrapper]]
@@ -19,7 +19,7 @@ import org.unibo.scooby.dsl.DSL.{ConfigurationWrapper, ScrapingResultSetting}
  * @return an empty [[ConfigurationWrapper]]
  */
 private inline def emptyWrapper[T]: ConfigurationWrapper[T] =
-  new ConfigurationWrapper(Configuration.empty[T], ScrapingResultSetting[T]())
+  new ConfigurationWrapper(Configuration.empty[T])
 
 /**
  * Generates a new [[Configuration]] that also includes a default standard output exporting. Useful, for example, to

--- a/src/main/scala/dsl/Scrape.scala
+++ b/src/main/scala/dsl/Scrape.scala
@@ -1,7 +1,7 @@
 package org.unibo.scooby
 package dsl
 
-import dsl.DSL.{ConfigurationWrapper, ScrapingResultSetting}
+import dsl.DSL.ConfigurationWrapper
 import utility.document.*
 
 import monocle.syntax.all.*
@@ -59,5 +59,4 @@ object Scrape:
         doc =>
           given ScrapeDocument = doc
           block
-      globalScope.scrapingResultSetting = ScrapingResultSetting[T]()
 


### PR DESCRIPTION
It was a class necessary to assist Scala with its type inference.
Its usage inside the DSL is no longer necessary.